### PR TITLE
fix: vcpu number can not be larger than 9

### DIFF
--- a/collectors/kvm_debug_stat_util.go
+++ b/collectors/kvm_debug_stat_util.go
@@ -48,7 +48,11 @@ func (dirMap DirMap) dirPathToLabel(dirPath string) ([]string, error) {
 	}
 
 	if vcpu != "" {
-		return []string{vm, vcpu[len(vcpu)-1:]}, nil
+		var vcpu_id string
+		if _, err := fmt.Sscanf(vcpu, "vcpu%v", &vcpu_id); err != nil {
+			return nil, errors.New("parse vcpu id error")
+		}
+		return []string{vm, vcpu_id}, nil
 	}
 
 	return []string{vm}, nil


### PR DESCRIPTION
In the previous implementation, kvm_exporter can not get a vcpu number that is larger or equals to 10. As the `vcpu[len(vcpu)-1:]` gets only the last character, string "vcpu10" will get "0" instead of "10", which leads to error logs like this:
```
time="2024-09-20T08:04:06Z" level=info msg="error gathering metrics: 36 error(s) occurred:\n* collected metric \"kvm_stat_vcpu_guest_mode_count\" { label:<name:\"domain\" value:\"sched_ext\" > label:<name:\"vcpu\" value:\"0\" > gauge:<value:0 > } was collected before with the same name and label values\n* collected metric \"kvm_stat_vcpu_lapic_timer_advance_ns_count\" { label:<name:\"domain\" value:\"sched_ext\" > label:<name:\"vcpu\" value:\"0\" > gauge:<value:1000 > } was collected before with the same name and label values\n* collected metric \"kvm_stat_vcpu_pid_count\" { label:<name:\"domain\" value:\"sched_ext\" > label:<name:\"vcpu\" value:\"0\" > gauge:<value:11517 > } was collected before with the same name and label values\n* collected metric \"kvm_stat_vcpu_tsc_offset_count\" { label:<name:\"domain\" value:\"sched_ext\" > label:<name:\"vcpu\" value:\"0\" > gauge:<value:-5.743228100496e+12 > } was collected before with the same name and label values\n* collected metric \"kvm_stat_vcpu_tsc_scaling_ratio_count\" { label:<name:\"domain\" value:\"sched_ext\" > label:<name:\"vcpu\" value:\"0\" > gauge:<value:4.294967296e+09 > } was collected before with the same name and label values\n* collected metric \"kvm_stat_vcpu_tsc_scaling_ratio_frac_bits_count\" { label:<name:\"domain\" value:\"sched_ext\" > label:<name:\"vcpu\" value:\"0\" > gauge:<value:32 > } was collected before with the same name and label values\n* collected metric \"kvm_stat_vcpu_guest_mode_count\" { label:<name:\"domain\" value:\"sched_ext\" > label:<name:\"vcpu\" value:\"1\" > gauge:<value:0 > } was collected before with the same name and label values\n
```